### PR TITLE
Ignore IDEA IDE settings and project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+.idea/**
+*.iml


### PR DESCRIPTION
IDEs like Intellij IDEA allow easy development of node projects.

 I don't propose this is enforced, but ignoring IDEA project files allows dev from within Intellij without cluttering the repo.
