### PR TITLE
Fix for Internet Explorer masthead bug

### DIFF
--- a/static/style/main.less
+++ b/static/style/main.less
@@ -92,6 +92,7 @@ body {
 }
 
 #site-title svg {
+    width: 173px;
     height: 33px;
     margin-top: 16px;
 }

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -13,7 +13,7 @@
         <header id="masthead">
             <div id="head-content">
                 <a id="site-title" href="/">
-                    <svg viewBox="0 0 503.14961 99.212598">
+                    <svg viewBox="0 0 503.14961 99.212598" preserveaspectratio="xMinYMin meet">
                         <use xlink:href="images/defs.svg#icon-textlogo"></use>
                     </svg>
                 </a>


### PR DESCRIPTION
IE had centred the CSB logo in desktop view where it shouldn't. Adding a width to this element should fix this issue.
