### PR TITLE
Updated layout of blog post info in mobile view

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -14,6 +14,9 @@ exports.truncateAndRemoveHTML = function (str, len) {
 
         return new_str + '&hellip;'; 
     }
+    if (str.indexOf('[…]', str.length - 3) !== -1) {
+        str = str.substring(0, str.length - 3);
+    }
     return str;
 };
 

--- a/static/style/blogs.less
+++ b/static/style/blogs.less
@@ -98,6 +98,15 @@ article footer {
     float: right;
 }
 
+.read-more {
+    color: @accent-color;
+    text-decoration: none;
+}
+
+.read-more:hover {
+    text-decoration: underline;
+}
+
 #nav-pages {
     margin: 18px 8px 0px 8px;
 }
@@ -199,5 +208,19 @@ article footer {
     
     article p {
         font-size: 14px;
+    }
+}
+
+@media screen and (max-width: 390px) {
+    .article-info .article-author {
+        display: block;
+        margin-top: 1px;
+        float: none;
+    }
+    
+    .article-info .article-date {
+        display: block;
+        margin-top: 0px;
+        float: none;
     }
 }

--- a/static/style/profile.less
+++ b/static/style/profile.less
@@ -239,6 +239,15 @@ article {
     margin-bottom: 6px;
 }
 
+.read-more {
+    color: @accent-color;
+    text-decoration: none;
+}
+
+.read-more:hover {
+    text-decoration: underline;
+}
+
 hr {
     margin-top: 16px;
 }

--- a/views/blogs.handlebars
+++ b/views/blogs.handlebars
@@ -9,7 +9,7 @@
             <h2><a href="{{link}}">{{title}}</a></h2>
         </header>
         {{#if imageUrl}}<img src="{{imageUrl}}" alt="Featured Image"/>{{/if}}
-        <p>{{{truncateAndRemoveHTML summary 400}}} <a href="{{link}}">Read more &#8594;</a></p>
+        <p>{{{truncateAndRemoveHTML summary 400}}} <a class="read-more" href="{{link}}">Read more &#8594;</a></p>
         <footer>
             <div class="article-info">
                 <a class="avatar" href="/bloggers/{{author.vanityUrl}}" style="background-image: url('{{author.avatarUrl}}');"></a>

--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -102,7 +102,7 @@
             <h4><a href="{{link}}">{{title}}</a></h4>
             <p class="article-date">{{formatDateLong pubDate}}</p>
             {{#if imageUrl}}<img src="{{imageUrl}}" alt="Featured Image"/>{{/if}}
-            <p>{{{truncateAndRemoveHTML summary 400}}} <a href="{{link}}">Read more &#8594;</a></p>
+            <p>{{{truncateAndRemoveHTML summary 400}}} <a class="read-more" href="{{link}}">Read more &#8594;</a></p>
             {{#unless @last}}<hr/>{{/unless}}
         </article>
         {{/each}}

--- a/website.js
+++ b/website.js
@@ -12,7 +12,7 @@ exports.serveRoutes = function(app) {
             if (error) { internalError(res, error); }
             else {
                 res.render('blogs', {
-    	            title: 'Blogs / CS Blogs',
+    	            title: 'Home / CS Blogs',
     	            blogs: blogs,
                     pageNumber: pageNumber,
                     hasLess: showBack,


### PR DESCRIPTION
- On smaller screens, the blog author/date will display on two lines.
- Added CSS style for ‘read more’ link.
- Removed […] from WordPress blogs in ‘truncateAndRemoveHTML’ helper.
