### PR TITLE
API and RSS feeds return same output as website unless queried otherwise

### DIFF
--- a/api.js
+++ b/api.js
@@ -9,36 +9,40 @@ exports.serveRoutes = function(router) {
             if (error) {
                 res.send(error);
             }
-            else {                
+            else {
+                if (req.query.original !== 'true') {
+                    BlogController.removeAllHTML(blogs, 400);
+                }
+
                 var page = {
                     blogs: blogs,
                     pageNumber: pageNumber,
                     hasLess: showBack,
                     hasMore: showNext
                 };
-                
+
                 res.json(page);
             }
         });
     });
-    
+
     router.get('/v0.1/bloggers', function(req, res) {
-		BloggerController.getAllProfiles(true, function (profiles, error) {
-			if(error) {
-				res.send(error);
-			}
-			else {
-				res.json(profiles);
-			}
-		});
-	});
-	
+        BloggerController.getAllProfiles(true, function (profiles, error) {
+            if(error) {
+                res.send(error);
+            }
+            else {
+                res.json(profiles);
+            }
+        });
+    });
+
     router.get('/v0.1/bloggers/:vanityurl', function(req, res) {
-		var vanityUrl = req.params.vanityurl;
-		BloggerController.getProfileByVanityUrl(vanityUrl, req, function (profile, page, error) {
-			if(error) {
-				res.send(error);
-			}
+        var vanityUrl = req.params.vanityurl;
+        BloggerController.getProfileByVanityUrl(vanityUrl, req, function (profile, page, error) {
+            if(error) {
+                res.send(error);
+            }
             else if (profile && page) {
                 var blogger = {
                     profile: profile,
@@ -46,12 +50,12 @@ exports.serveRoutes = function(router) {
                 };
                 res.json(blogger);
             }
-			else {
-				sendError(res, 404, 'Blogger not found');
-			}
-		});
-	});
-    
+            else {
+                sendError(res, 404, 'Blogger not found');
+            }
+        });
+    });
+
     // Handle error 404
     router.use(function(req, res) {
         console.error('ERROR 404. Request: %j', req);
@@ -60,7 +64,7 @@ exports.serveRoutes = function(router) {
             error: '404 Not Found'
         });
     });
-    
+
     // Handle error 500
     router.use(function(error, req, res, next) {
         console.error("ERROR 500. Error: %j", error);
@@ -69,7 +73,7 @@ exports.serveRoutes = function(router) {
             error: 'Internal Server Error: ' + error
         });
     });
-    
+
     function sendError(res, errorCode, errorMessage) {
         res.status(errorCode);
         res.json({

--- a/controllers/blog.js
+++ b/controllers/blog.js
@@ -4,22 +4,28 @@ var Blog = require("../models/blog").Blog;
 var Blogger = require("../models/blogger").Blogger;
 var BloggerController = require("./blogger")
 var paginate = require('express-paginate');
+var sanitizeHtml = require('sanitize-html');
 
 //Done of form (blogs, pageNumber, showBack, showNext, error)
 exports.getPaginatedBlogs = function (options, req, done) {
     Blog.paginate(options, req.query.page, req.query.limit, function (error, pageCount, blogs, itemCount) {
-        if (error) { done(null, -1, false, false, error); }
+        if (error) {
+            done(null, -1, false, false, error);
+        }
         else {
             // Attach bloggers to blogs
             BloggerController.getAllProfiles(true, function(allBloggers, error) {
-                if (error) { done(null, -1, false, false, error); }
+                if (error) {
+                    done(null, -1, false, false, error);
+                }
                 else {
-                    blogs.forEach(function(thisBlog, index, blogsArray) {
-                        //Associate each blog with its blogger
-                        blogsArray[index].author = allBloggers.filter(function(element) {
-                            return ((element.userId == thisBlog.userId) && (element.userProvider == thisBlog.userProvider));
+                    for (var i = 0; i < blogs.length; ++i) {
+                        // Associate each blog with its blogger
+                        blogs[i].author = allBloggers.filter(function(element) {
+                            return ((element.userId == blogs[i].userId) && (element.userProvider == blogs[i].userProvider));
                         })[0];
-                    });
+                    }
+
                     done(blogs, req.query.page, (req.query.page > 1), paginate.hasNextPages(req)(pageCount), null);
                 }
             });
@@ -27,26 +33,68 @@ exports.getPaginatedBlogs = function (options, req, done) {
     }, {sortBy: {pubDate : 'desc'}, columns: {__v: 0}});
 };
 
-//Done of form (allBlogs, error)
-exports.getAllBlogs = function (options, done) {
-    Blog.find(options, function(error, allBlogs) {
-        if(error) {
+//Done of form (recentBlogs, error)
+exports.getMostRecentBlogs = function(options, howMany, done) {
+    Blog.find(options, null, {skip: 0, limit: howMany, sort: {pubDate: 'desc'}}, function(error, recentBlogs) {
+        if (error) {
             done(null, error);
         }
         else {
-            done(allBlogs, null);
+            // Attach bloggers to blogs
+            BloggerController.getAllProfiles(true, function(allBloggers, error) {
+                if (error) {
+                    done(null, error);
+                }
+                else {
+                    for (var i = 0; i < recentBlogs.length; ++i) {
+                        // Associate each blog with its blogger
+                        recentBlogs[i].author = allBloggers.filter(function(element) {
+                            return ((element.userId == recentBlogs[i].userId) && (element.userProvider == recentBlogs[i].userProvider));
+                        })[0];
+                    }
+
+                    done(recentBlogs, null);
+                }
+            });
         }
     });
 };
 
-//Done of form (recentBlogs, error)
-exports.getMostRecentBlogs = function(options, howMany, done) {
-    Blog.find(options, null, {skip: 0, limit: howMany, sort: {pubDate: -1}}, function(error, recentBlogs) {
-       	if(error) {
-            done(null, error);
-        }
-        else {
-            done(recentBlogs, null);
-        }
+exports.truncateAndRemoveHTML = function(str, len) {
+    str = sanitizeHtml(str, {
+        allowedTags: [],
+        allowedAttributes: {}
     });
+    if (str.length > len && str.length > 0) {
+        var new_str = str + " ";
+        new_str = str.substr(0, len);
+        new_str = str.substr(0, new_str.lastIndexOf(" "));
+        new_str = (new_str.length > 0) ? new_str : str.substr(0, len);
+
+        return new_str + '&hellip;';
+    }
+
+    // Some blogs leave annoying bits at then end, such as their own
+    // continue reading link or ellipses. Remove these.
+    var continueReadingPosition = str.indexOf('… Continue reading →');
+    if (continueReadingPosition !== -1) {
+        str = str.substring(0, continueReadingPosition);
+    }
+
+    var readMorePosition = str.indexOf('... Read more');
+    if (readMorePosition !== -1) {
+        str = str.substring(0, readMorePosition);
+    }
+
+    if (str.indexOf('[…]', str.length - 3) !== -1) {
+        str = str.substring(0, str.length - 3);
+    }
+
+    return str.trim();
 };
+
+exports.removeAllHTML = function(blogs, len) {
+    for (var i = 0; i < blogs.length; ++i) {
+        blogs[i].summary = exports.truncateAndRemoveHTML(blogs[i].summary, len);
+    }
+}

--- a/controllers/blogger.js
+++ b/controllers/blogger.js
@@ -103,7 +103,7 @@ exports.validate = function(newBlogger, done) {
     newBlogger.sanitize();
     newBlogger.validate(function(errors) {
         isVanityUrlTaken(newBlogger, function(taken, error) {
-            validateUserSubmittedUrls(newBlogger, function (brokenUrls) {
+            validateUserSubmittedUrls(newBlogger, function(brokenUrls) {
                 if (error) {
                     return done(null, null, error);
                 }
@@ -115,13 +115,13 @@ exports.validate = function(newBlogger, done) {
                     });
                 }
 
-                brokenUrls.forEach(function(brokenUrl) {
+                for (var i = 0; i < brokenUrls.length; ++i) {
                    errors.push({
-                       parameter: brokenUrl.name,
-                       value: brokenUrl.location,
+                       parameter: brokenUrls[i].name,
+                       value: brokenUrls[i].location,
                        message: 'URL doesn\'t appear to link to valid location.'
                    });
-                });
+                }
 
                 if (brokenUrls.length > 0) { console.log("%j", brokenUrls); }
                 if (errors.length > 0) { console.log("%j", errors); }

--- a/feeds.js
+++ b/feeds.js
@@ -5,28 +5,31 @@ var BloggerController = require('./controllers/blogger');
 var RSS = require('rss');
 
 exports.serveRoutes = function(router) {
-	router.get('/main', function(req, res) {
-		var mainFeed = new RSS({
-			title: "CS Blogs Main Feed",
-			description: "All of the blog posts from bloggers on CSBlogs.com",
-			feed_url: "http://feeds.csblogs.com/main",
-			site_url: "http://csblogs.com",
-		});
-		
-		BlogController.getMostRecentBlogs({}, 20, function(blogs, error) {
-			blogs.forEach(function(blog) {
-				mainFeed.item({
-					title: 			blog.title,
-					description: 	blog.summary,
-					url: 			blog.link,
-					guid: 			blog.link,
-					author: 		"CS Blogs User",
-					date: 			blog.pubDate
-				});	
-			});
-			
-			res.header('Content-Type','application/rss+xml');
-			res.send(mainFeed.xml({indent: true}));
-		});
-	});	
+    router.get('/main', function(req, res) {
+        var mainFeed = new RSS({
+            title: "Computer Science Blogs",
+            description: "All of the posts from bloggers on CSBlogs.com",
+            feed_url: "http://feeds.csblogs.com/main",
+            site_url: "http://csblogs.com",
+        });
+
+        BlogController.getMostRecentBlogs({}, 20, function(blogs, error) {
+            if (req.query.original !== 'true') {
+                BlogController.removeAllHTML(blogs, 400);
+            }
+            for (var i = 0; i < blogs.length; ++i) {
+                mainFeed.item({
+                    title: 			blogs[i].title,
+                    description: 	blogs[i].summary,
+                    url: 			blogs[i].link,
+                    guid: 			blogs[i]._id.toString(),
+                    author: 		blogs[i].author.firstName + ' ' + blogs[i].author.lastName,
+                    date: 			blogs[i].pubDate
+                });
+            }
+
+            res.header('Content-Type','application/rss+xml');
+            res.send(mainFeed.xml({indent: true}));
+        });
+    });
 };

--- a/server.js
+++ b/server.js
@@ -76,14 +76,14 @@ database.once('open', function(callback) {
     // Import routes (and thus serve the site) if the database connection worked
     feeds.serveRoutes(feedsRouter);
     app.use(subdomain('feeds', feedsRouter));
-    
+
     api.serveRoutes(apiRouter);
     app.use(subdomain('api', apiRouter));
-    
+
     authentication.serveOAuthRoutes(app);
-    
+
     website.serveRoutes(app);
-    
+
     console.log('Now serving all routes!');
 });
 

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,38 +1,10 @@
 "use strict";
 
 var moment = require('moment');
-var sanitizeHtml = require('sanitize-html');
+var BlogController = require('../controllers/blog');
 
-exports.truncateAndRemoveHTML = function (str, len) {
-    str = sanitizeHtml(str, {
-        allowedTags: [],
-        allowedAttributes: {}
-    });
-    if (str.length > len && str.length > 0) {
-        var new_str = str + " ";
-        new_str = str.substr (0, len);
-        new_str = str.substr (0, new_str.lastIndexOf(" "));
-        new_str = (new_str.length > 0) ? new_str : str.substr (0, len);
-
-        return new_str + '&hellip;';
-    }
-
-    //Some blogs leave annoying bits at then end, such as their own
-    //continue reading link or ellipses. Remove these.
-    var continueReadingPosition = str.indexOf('… Continue reading →');
-    if(continueReadingPosition !== -1) {
-        str = str.substring(0, continueReadingPosition);
-    }
-
-    var readMorePosition = str.indexOf('... Read more');
-    if(readMorePosition !== -1) {
-        str = str.substring(0, readMorePosition);
-    }
-
-    if (str.indexOf('[…]', str.length - 3) !== -1) {
-        str = str.substring(0, str.length - 3);
-    }
-    return str;
+exports.truncateAndRemoveHTML = function(str, len) {
+    return BlogController.truncateAndRemoveHTML(str, len);
 };
 
 exports.formatDateShort = function(datestamp) {


### PR DESCRIPTION
- HTML is removed from summaries in both the API and RSS blog feeds unless the query 'original=true' is used.
- Moved truncateAndRemoveHTML helper to blog controller.
- Replaced some for each loops with faster for loops.
