### PR TITLE
Fixed incorrect method of determining when to use relative date

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -11,7 +11,7 @@ exports.formatDateShort = function(datestamp) {
     try {
         var date = moment(datestamp);
 
-        if (date.isBefore(moment(), 'week')) {
+        if (moment().diff(date, 'days') > 6) {
             return date.format('MMM D, YYYY');
         }
         else {
@@ -26,13 +26,7 @@ exports.formatDateShort = function(datestamp) {
 exports.formatDateLong = function(datestamp) {
     try {
         var date = moment(datestamp);
-
-        if (date.isBefore(moment(), 'week')) {
-            return date.format('MMMM D, YYYY  h:mm a');
-        }
-        else {
-            return date.fromNow();
-        }
+        return date.format('MMMM D, YYYY h:mm a');
     }
     catch (error) {
         return '';


### PR DESCRIPTION
- Relative dates where only being used if the date was inside the current week. It was meant to be relative up to a week behind (7 days).
- Removed relative date from long formatter so full date/time is always given on profile pages.
